### PR TITLE
Add server_info to publish() in Admin UI

### DIFF
--- a/lektor/admin/modules/api.py
+++ b/lektor/admin/modules/api.py
@@ -305,7 +305,7 @@ def publish_build():
     def generator():
         try:
             event_iter = publish(info.env, server_info.target,
-                                 info.output_path) or ()
+                                 info.output_path, server_info=server_info) or ()
             for event in event_iter:
                 yield {'msg': event}
         except PublishError as e:


### PR DESCRIPTION
This ensures that deployment plugins (such as `lektor-s3`) receive the same server_info data when called from the admin UI as they do when run from the CLI. 

(As is the case with `lektor-s3`, which needs this parameter for Cloudfront invalidation.)